### PR TITLE
NW-4112 Use the created parameter group name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
   enable_create_db_subnet_group = var.db_subnet_group_name == "" ? var.create_db_subnet_group : false
 
   parameter_group_name    = var.parameter_group_name != "" ? var.parameter_group_name : var.identifier
-  parameter_group_name_id = var.parameter_group_name != "" ? var.parameter_group_name : module.db_parameter_group.this_db_parameter_group_id
+  parameter_group_name_id = var.create_db_parameter_group ? module.db_parameter_group.this_db_parameter_group_id : var.parameter_group_name
 
   option_group_name             = var.option_group_name != "" ? var.option_group_name : module.db_option_group.this_db_option_group_id
   enable_create_db_option_group = var.create_db_option_group ? true : var.option_group_name == "" && var.engine != "postgres"


### PR DESCRIPTION
We've a [failing job of Tokoroten](https://jenkins.test.mytheresa.services/job/services/job/tokoroten/job/infrastructure/job/mytcloud-test/job/eu-central-1/job/tokorotendb/job/dev/job/update/job/master/28/console) that's trying to delete the parameter group, but it's not updating the new one. Because it's trying to guess the name of the parameter group instead of using the output of the already created parameter group 🤷‍♂️

This PR makes the module use the output of the module that creates the parameter group, instead of trying to guess it.

This change is being tested on https://github.com/mytheresa/tokoroten-infra/pull/17